### PR TITLE
Login form at root (#70)

### DIFF
--- a/the-tavern-desktop/src/app/components/basic-form.tsx
+++ b/the-tavern-desktop/src/app/components/basic-form.tsx
@@ -1,22 +1,26 @@
 import BasicButton from "./navigation/basic-button";
 
-"use client"
-
 export function BasicForm({
     children, 
     title, 
+    formStyles,
     onSubmit}: {
         children: React.ReactNode; 
-        title: string; 
-        onSubmit: () => void}) {
+        title: string;
+        formStyles?: {
+          titleStyle?: React.CSSProperties
+          formStyle?: React.CSSProperties
+          buttonStyle?: React.CSSProperties
+        };
+        onSubmit?: () => void}) {
   return (
-    <form>
+    <form style={formStyles?.formStyle}>
         
-      <p>{title}</p>
+      <h1 style={formStyles?.titleStyle}>{title}</h1>
 
       {children}
 
-      <BasicButton onClick={onSubmit}> 
+      <BasicButton onClick={onSubmit} buttonStyle={formStyles?.buttonStyle}>
         Submit
       </BasicButton>
 

--- a/the-tavern-desktop/src/app/components/login-form.tsx
+++ b/the-tavern-desktop/src/app/components/login-form.tsx
@@ -1,0 +1,53 @@
+import { BasicForm } from './basic-form'
+
+export default function LoginForm(){
+    return (
+        <BasicForm 
+            title='Login' 
+            formStyles={{
+                formStyle: styles.formStyle,
+                buttonStyle: styles.buttonStyle,
+                titleStyle: styles.titleStyle
+            }}
+        >
+            <div style={styles.inputContainer}>
+                <input type="text" placeholder='Username' />
+            </div>
+            <div style={styles.inputContainer}>
+                <input type="password" placeholder='Password' />
+            </div>
+        </BasicForm>
+    );
+}
+
+
+const styles = {
+    inputContainer: {
+        marginTop: 10,
+        marginBottom: 10,
+        borderColor: '#000000ff'
+    },
+
+    formStyle: {
+        display: 'flex',
+        flexDirection: 'column' as const,
+        border: '10px solid #ddd',
+        padding: 14,
+        borderRadius: 12,
+        backgroundColor: '#ffffff',
+        borderWidth: 1,
+        borderColor: '#1affff',
+        boxShadow: '0 0 10px rgba(26,255,255,0.8)',
+    },
+
+    buttonStyle: {
+        background: 'aqua',
+        border: '2px solid #000',
+        borderRadius: 12,
+    },
+
+    titleStyle: {
+        fontSize: 24
+    }
+
+}

--- a/the-tavern-desktop/src/app/components/navigation/basic-button.tsx
+++ b/the-tavern-desktop/src/app/components/navigation/basic-button.tsx
@@ -1,18 +1,17 @@
-"use client"
-
 
 export default function BasicButton({ 
   children, 
   onClick,
-  className,
-}: {
-    children: React.ReactNode, 
+  buttonStyle,
+  }: {
+    children?: React.ReactNode, 
     onClick?: () => void, 
-    className?: string
-  }) {
+    className?: string,
+    buttonStyle: React.CSSProperties | undefined; }
+  ) {
 
   return (
-    <button onClick={onClick} className={className}>
+    <button onClick={onClick} style={buttonStyle}>
       {children}
     </button>
     );

--- a/the-tavern-desktop/src/worker.tsx
+++ b/the-tavern-desktop/src/worker.tsx
@@ -12,6 +12,7 @@ import { AppLayout } from "./app/layouts/AppLayout";
 import { userRoutes } from "./features/users/usersRoutes";
 import { UserPage } from "./app/pages/UserPage";
 import { ChatPage } from "./app/pages/ChatPage";
+import LoginForm from "./app/components/login-form";
 
 export interface Env {
   DB: D1Database;
@@ -34,6 +35,7 @@ export default defineApp([
             <h1>Start</h1>
             <p>Velkommen til eksempel</p>
             <p>Databasen har {userResult.length} brukere</p>
+            <LoginForm/>
           </div>
         );
       }),


### PR DESCRIPTION
# Description
I know I said I'd be focusing mainly on the backend but I couldn't help myself.
<img width="548" height="196" alt="image" src="https://github.com/user-attachments/assets/807be2af-87f2-48c1-99ba-c42683c41b14" />


> [!IMPORTANT]
> Removed the "use client" thingy for now until we figure out how they made it not bug out during the course. I don't remember how he did it, but will fix whenever the recording comes out so I can see.
- Made a login form based on basic form
- Set up a login form at root
- Made the styling drill down from basic button and the basic form. This obviously isn't optimal and will hopefully be replaced by useTheme hooks in the future.