### PR TITLE
fix: reorder migration to resolve FK constraint error

### DIFF
--- a/the-tavern-desktop/drizzle/0001_mute_nick_fury.sql
+++ b/the-tavern-desktop/drizzle/0001_mute_nick_fury.sql
@@ -1,11 +1,3 @@
-CREATE TABLE `user_friends` (
-	`user_id` integer NOT NULL,
-	`friend_id` integer NOT NULL,
-	PRIMARY KEY(`user_id`, `friend_id`),
-	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action,
-	FOREIGN KEY (`friend_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
-);
---> statement-breakpoint
 PRAGMA foreign_keys=OFF;--> statement-breakpoint
 CREATE TABLE `__new_users` (
 	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -19,4 +11,11 @@ CREATE TABLE `__new_users` (
 INSERT INTO `__new_users`("id", "name", "password", "joined_at", "role", "token") SELECT "id", "name", "password", "joined_at", "role", "token" FROM `users`;--> statement-breakpoint
 DROP TABLE `users`;--> statement-breakpoint
 ALTER TABLE `__new_users` RENAME TO `users`;--> statement-breakpoint
-PRAGMA foreign_keys=ON;
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `user_friends` (
+	`user_id` integer NOT NULL,
+	`friend_id` integer NOT NULL,
+	PRIMARY KEY(`user_id`, `friend_id`),
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`friend_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);


### PR DESCRIPTION
An oversight in the auto-generated migration led to foreign key constraint errors.
The user_friends table references users(id), so we need to create the users table 
first before creating user_friends to avoid FOREIGN KEY constraint failed errors.